### PR TITLE
Country interface fixes and CountryName method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,23 @@ export class NovelCovid {
 	}
 
 	/**
+	 * @description Returns all the available countries.
+	 * @returns {Array<string>}
+	 */
+	async countriesNames(): Promise<Array<string>> {
+		this.countries().then(data => {
+			if(data) {
+				let countries = data as unknown as Country[];
+				return countries.map(x => x.country).sort();
+			} else {
+				return new Array<string>();
+			}
+		});
+
+		return new Array<string>();
+	}
+
+	/**
 	 * @description Fetches data of corona virus in United States.
 	 * @param {String} [state=null] - State name data you wanna fetch.
 	 * @returns {Promise<Array<State> | State | null>}
@@ -126,13 +143,15 @@ export interface Country {
 		iso2: string;
 	};
 	cases: number;
-	todaysCases: number;
+	todayCases: number;
 	deaths: number;
+	todayDeaths: number;
 	recovered: number;
 	active: number;
 	critical: number;
 	casesPerOneMillion: number;
 	deathsPerOneMillion: number;
+	updated: number;
 }
 
 export interface State {


### PR DESCRIPTION
I've installed today the node.js "wrapper" for Ionic and saw that "Country" interface doesn't match what the API really returns. Also, I needed a "CountryName" method, so I created one there, since there might be more people wanting to use it.

Thanks.